### PR TITLE
Fix Typo in Input Selector: `nubmer` to `number`

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -78,7 +78,7 @@ $(() => {
     })
 
     $options.find('select, input').change(updateBitMeter)
-    $options.find('input[type=nubmer]').on('input', updateBitMeter)
+    $options.find('input[type=number]').on('input', updateBitMeter)
     updateBitMeter()
   }
 


### PR DESCRIPTION
This pull request addresses a typo in the jQuery selector within ui.js. The typo was causing issues with selecting input elements of type number. Specifically, the selector was incorrectly written as input[type=nubmer] instead of input[type=number].

Changes Made:

Corrected the typo in the jQuery selector from $options.find('input[type=nubmer]') to $options.find('input[type=number]').
Impact:

This change ensures that the input event is properly bound to input elements of type number, allowing the updateBitMeter function to be called correctly when the input value changes.